### PR TITLE
Setup Heroku review app

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,14 @@
 {
   "name": "judgels-web",
   "scripts": {},
-  "env": {},
+  "env": {
+    "NODE_MODULES_CACHE": {
+      "required": true
+    },
+    "NPM_CONFIG_PRODUCTION": {
+      "required": true
+    }
+  },
   "formation": {},
   "addons": [],
   "buildpacks": [

--- a/app.json
+++ b/app.json
@@ -1,0 +1,12 @@
+{
+  "name": "judgels-web",
+  "scripts": {},
+  "env": {},
+  "formation": {},
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -2,12 +2,8 @@
   "name": "judgels-web",
   "scripts": {},
   "env": {
-    "NODE_MODULES_CACHE": {
-      "required": true
-    },
-    "NPM_CONFIG_PRODUCTION": {
-      "required": true
-    }
+    "NODE_MODULES_CACHE": "false",
+    "NPM_CONFIG_PRODUCTION": "false"
   },
   "formation": {},
   "addons": [],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint bin build config server src",
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
-    "test": "", // yep, currently no test :P
+    "test": "",
     "postinstall": "node semantic/semantic-fix.js",
     "heroku-postbuild": "npm run deploy:prod",
     "dev": "better-npm-run dev",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint bin build config server src",
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
-    "test": "",
+    "test": "true",
     "postinstall": "node semantic/semantic-fix.js",
     "heroku-postbuild": "npm run deploy:prod",
     "dev": "better-npm-run dev",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint bin build config server src",
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
-    "serve": "better-npm-run start",
+    "test": "", // yep, currently no test :P
     "postinstall": "node semantic/semantic-fix.js",
     "heroku-postbuild": "npm run deploy:prod",
     "dev": "better-npm-run dev",


### PR DESCRIPTION
- We would like to use this configuration: https://devcenter.heroku.com/articles/github-integration-review-apps (hard to do in Travis?) so can preview the change in disposable url.
- Heroku tests (paid) is longer than Travis tests (free), but easier to understand (same with `npm run test`)
- If we remove Travis, we won't need to keep .travis.yml anymore